### PR TITLE
feat: add Sign In API endpoint

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,33 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, EmailStr
+
+app = FastAPI(title="Nebula API", version="0.1.0")
+
+# In-memory user store (replace with database in production)
+users_db: dict[str, dict] = {}
+
+
+class SignInRequest(BaseModel):
+    email: str
+    password: str
+
+
+@app.post("/api/user/login")
+def sign_in(request: SignInRequest):
+    """Sign in an existing user."""
+    # Find user by email
+    user = users_db.get(request.email)
+
+    if user is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"result": False, "message": "user not found"},
+        )
+
+    if user["password"] != request.password:
+        raise HTTPException(
+            status_code=401,
+            detail={"result": False, "message": "incorrect password"},
+        )
+
+    return {"result": True, "message": "login successful"}


### PR DESCRIPTION
## Summary
Implements the Sign In API as specified in #11.

### Endpoint
- **POST** `/api/user/login`

### Request
```json
{
  "email": "billionto@gmail.com",
  "password": "HelloWorld@1"
}
```

### Response (Success) [200]
```json
{
  "result": true,
  "message": "login successful"
}
```

### Response (User Not Found) [404]
```json
{
  "result": false,
  "message": "user not found"
}
```

### Response (Wrong Password) [401]
```json
{
  "result": false,
  "message": "incorrect password"
}
```

### Implementation Details
- Uses Pydantic `BaseModel` for request validation
- In-memory user store (ready for database integration)
- Proper HTTP status codes for each error case

Closes #11

## Test plan
- [x] Returns 404 when user email doesn't exist
- [x] Returns 401 when password is incorrect
- [x] Returns 200 with success message on valid credentials

