### PR TITLE
feat: add Sign Up API endpoint

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="Nebula API", version="0.1.0")
+
+# In-memory user store (replace with database in production)
+users_db: dict[str, dict] = {}
+
+
+class SignUpRequest(BaseModel):
+    firstname: str
+    lastname: str
+    email: str
+    username: str
+    password: str
+
+
+@app.post("/api/user/register")
+def sign_up(request: SignUpRequest):
+    """Register a new user."""
+    if request.email in users_db:
+        raise HTTPException(
+            status_code=409,
+            detail={"result": False, "message": "an user already exist in this email"},
+        )
+
+    users_db[request.email] = {
+        "firstname": request.firstname,
+        "lastname": request.lastname,
+        "email": request.email,
+        "username": request.username,
+        "password": request.password,
+    }
+
+    return {"result": True, "message": "successfully registered"}


### PR DESCRIPTION
## Summary
Implements the Sign Up API as specified in #1.

### Endpoint
- **POST** `/api/user/register`

### Request
```json
{
  "firstname": "Biswajit",
  "lastname": "Das",
  "email": "billionto@gmail.com",
  "username": "biltudas1",
  "password": "Biltu@123"
}
```

### Response (Success) [200]
```json
{
  "result": true,
  "message": "successfully registered"
}
```

### Response (Conflict) [409]
```json
{
  "result": false,
  "message": "an user already exist in this email"
}
```

Closes #1

## Test plan
- [x] Returns 200 with success message on new registration
- [x] Returns 409 when email already exists
- [x] Request body validated by Pydantic (422 on missing fields)

